### PR TITLE
Fix Repository Syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "redis": "^0.12.1",
     "request": "^2.58.0"
   },
-  "repository": "https://github.com/ibm-cds-labs/simple-search-service"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ibm-cds-labs/simple-search-service"
+  }
 }


### PR DESCRIPTION
The syntax for the `repository` field in `package.json` is incorrect, which is causing deployments to not be tracked correctly. This pull request fixes the syntax for the `repository` field in `package.json`.