### PR TITLE
issues #32, #34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ start.sh
 .jshintrc
 .project
 npm-debug.log
+.vscode

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ var express = require('express'),
   cache = require('./lib/cache.js'),
   schema = require('./lib/schema.js'),
   isloggedin = require('./lib/isloggedin.js'),
+  sssenv = require('./lib/sssenv.js'),
   inference = require('./lib/inference.js');
 
 
@@ -134,12 +135,17 @@ app.get('/settings', isloggedin(), function (req, res) {
 	 if (err) {
 	   return res.status(err.statusCode).send({error: err.error, reason: err.reason});
 	 }
+   data["appenv"] = sssenv;
 	 res.send(data);
 	});
 });
 
 app.post('/settings', isloggedin(), bodyParser, function(req, res) {
-	db.settings(req.body, function(err, data) {
+  var settings = req.body;
+  if (settings.hasOwnProperty("appenv")) {
+    delete settings.appenv;
+  }
+	db.settings(settings, function(err, data) {
 		 if (err) {
 		   return res.status(err.statusCode).send({error: err.error, reason: err.reason});
 		 }

--- a/lib/sssenv.js
+++ b/lib/sssenv.js
@@ -1,0 +1,54 @@
+var appEnv = require('cfenv').getAppEnv();
+
+var app =  {
+  name: appEnv.app ? (appEnv.app.application_name || null) : null,
+  id: appEnv.app ? (appEnv.app.application_id || null) : null,
+  urls: appEnv.app ? (appEnv.app.uris || null) : null,
+  host: null
+}
+
+if (!appEnv.isLocal && app.id) {
+  app.host = "https://console.ng.bluemix.net/?direct=classic/#/resources/appGuid=" + app.id;
+}
+
+var dbservice = appEnv.services["cloudantNoSQLDB"]
+                ? appEnv.services["cloudantNoSQLDB"][0]
+                : {};
+
+var cloudant = {
+  name: dbservice.name,
+  username: dbservice.credentials ? dbservice.credentials.username : null,
+  url: dbservice.credentials ? dbservice.credentials.url : null
+}
+
+if (cloudant.url) {
+  //strip username/password
+  cloudant.url = cloudant.url.replace(/:\/\/\S+:\S+@/i, '://');
+}
+else {
+  cloudant.url = dbservice.credentials ? (dbservice.credentials.host + ":" + dbservice.credentials.port) : "";
+}
+
+if (cloudant.url && cloudant.url.indexOf("cloudant.com") > -1) {
+  //cloudant.com
+  cloudant.url += "/dashboard.html#/database/seams/_all_docs";
+}
+else {
+  //couchdb
+  cloudant.url += "/_utils/database.html?seams";
+}
+
+var cacheservice = appEnv.getService("Redis by Compose") || {};
+var redis = {
+  name: (cacheservice.name || null),
+  username: cacheservice.credentials ? (cacheservice.credentials.username || null) : null,
+  host: cacheservice.credentials ? (cacheservice.credentials.public_hostname || null) : null
+};
+
+var sssenv = {
+  application: app,
+  storage: cloudant,
+  cache: redis
+};
+
+module.exports = sssenv;

--- a/public/js/seams.js
+++ b/public/js/seams.js
@@ -498,10 +498,12 @@ seamsApp.controller('seamsController', ['$scope', '$route', '$routeParams', '$lo
 			var restapi = '/settings';
 			$http.get(restapi)
 			  .success(function(data) {
+					$scope.$root.appenv = data ? data.appenv : {};
 				  $scope.$root.settings = data;
 			  })
 			  .error(function(data, status, headers, config) {
 			      console.log("Error retrieving settings:", data, status);
+						$scope.$root.appenv = $scope.$root.appenv || {};
 			      $scope.$root.settings = {};
 			  });
 		};

--- a/public/js/seams.js
+++ b/public/js/seams.js
@@ -466,7 +466,7 @@ seamsApp.controller('seamsController', ['$scope', '$route', '$routeParams', '$lo
 					var unfacetedfields = [];
 					var facetedfields = [];
 			        for(var i in data.fields) {
-			        	if (data.fields[i].type === "string") {
+			        	if (data.fields[i].type === "string" || data.fields[i].type === "arrayofstrings") {
 			        		if (data.fields[i].facet == true) {
 				                facetedfields.push(data.fields[i].name);
 				            }


### PR DESCRIPTION
for #32, instead of disabling the discovery, the initial issue has been addressed
for #34, there is now an appenv object available in the frontend (null for any values now available/defined):
"appenv": {
    "application": {
        "name":  "name-of-simple-search-service-application",
        "id":  "application-id",
        "urls": [ "appliction-route-1", "application-route-2" ],
        "host":  "bluemix-application-overview-url"
    },
    "storage": {
        "name":  "cloudant-service-name",
        "username":  "cloudant-service-username",
        "url":  "cluoudant-service-url"
    },
    "cache": {
        "name":  "redis-service-name",
        "username":  "redis-service-username",
        "host": "redis-service-hostname"
    }
}