### PR TITLE
Change the requirements for running locally to make it simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ The fastest way to deploy this application to Bluemix is to click the **Deploy t
 
 Clone this repository then run `npm install` to add the Node.js libraries required to run the app.
 
-Then create an environment variable that mimics Cloud Foundry e.g.
+Then create an environment variable that store your Cloudant URL:
 
 ```sh
-export VCAP_SERVICES='{"cloudantNoSQLDB":[{"name":"simple-search-service-cloudant-service","label":"cloudantNoSQLDB","plan":"Shared","credentials":{"username":"USERNAME","password":"PASSWORD","host":"HOSTNAME","port":443,"url":"https://USERNAME:PASSWORD@HOSTNAME"}}]}'
+export SSS_URL='https://USERNAME:PASSWORD@HOSTNAME'
 ```
 
 replacing the `USERNAME`, `PASSWORD` and `HOSTNAME` placeholders for your own Cloudant account's details.

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -1,5 +1,30 @@
-var services = process.env.VCAP_SERVICES;
-if (typeof services != 'undefined') {
-  services = JSON.parse(services);
+// If the Bluemix VCAP_SERVICES env variable is there
+// Use this to load credentials
+if (typeof process.env.VCAP_SERVICES !== 'undefined') {
+	var services = process.env.VCAP_SERVICES;
+	if (typeof services != 'undefined') {
+	  services = JSON.parse(services);
+	}
 }
+
+// Otherwise, look for the SSS_URL env variable
+// Build credentials object from that
+else if (typeof process.env.SSS_URL !== 'undefined') {
+	var services = {
+		cloudantNoSQLDB: [
+			{
+				credentials: {
+					url: process.env.SSS_URL
+				}
+			}
+		]	
+	}
+}
+
+// If we can't find any credentials
+// Throw error and die
+else {
+	throw new Error("Cloudant credentials not found");
+}
+
 module.exports = services;


### PR DESCRIPTION
I made this change on the CMS project and I think it is a bit simpler and more transparent for the user (i.e. they may not know about Cloud Foundry or understand what all the information they are providing is).

The SSS and the CMS both reference the same environment variable.