### PR TITLE
Issue55 - Fix Cloudant plan name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The application uses these Bluemix services:
 
 * a Node.js runtime
 * a Cloudant database
-* a Redis in-memory database from Compose.io (Optional)
 
 Once the data is uploaded, you can use the UI to browse and manage your data via the integrated CMS. Additionally, a CORS-enabled API endpoint is available at `<your domain name>/search`. The endpoint takes advantage of Cloudant's built-in integration for Lucene full-text indexing. Here's what you get:
 

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -29,23 +29,4 @@ else if (typeof process.env.SSS_CLOUDANT_URL === 'string') {
 	};
 }
 
-/*******
-	REDIS
-*******/
-
-if (typeof process.env.SSS_REDIS_HOST === 'string') {
-	console.log("Using local config for Redis");
-	services["user-provided"] = [
-    {
-      name: "Redis by Compose",
-      credentials: {
-      	public_hostname: process.env.SSS_REDIS_HOST,
-	      password: process.env.SSS_REDIS_PASSWORD || null
-      }
-	      
-    }
-  ];
-
-}
-
 module.exports = services;

--- a/lib/sssenv.js
+++ b/lib/sssenv.js
@@ -37,17 +37,9 @@ else {
   cloudant.url += "/_utils/database.html?seams";
 }
 
-var cacheservice = appEnv.getService("Redis by Compose") || {};
-var redis = {
-  name: (cacheservice.name || null),
-  username: cacheservice.credentials ? (cacheservice.credentials.username || null) : null,
-  host: cacheservice.credentials ? (cacheservice.credentials.public_hostname || null) : null
-};
-
 var sssenv = {
   application: app,
-  storage: cloudant,
-  cache: redis
+  storage: cloudant
 };
 
 module.exports = sssenv;

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 declared-services:
   simple-search-service-cloudant-service:
     label: cloudantNoSQLDB
-    plan: Shared
+    plan: Lite
 applications:
 - name: simple-search-service
   path: .

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "body-parser": "^1.13.2",
     "cf-deployment-tracker-client": "^0.x",
     "cfenv": "1.0.x",
-    "cloudant": "1.3.0",
+    "cloudant": "1.6.2",
     "compression": "^1.5.1",
     "cors": "^2.7.1",
     "couchimport": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "passport": "^0.3.2",
     "passport-anonymous": "^1.0.1",
     "passport-http": "^0.3.0",
-    "redis": "^0.12.1",
     "request": "^2.58.0",
     "socket.io": "^1.4.8",
     "underscore": "^1.8.3",


### PR DESCRIPTION
As per issue #55, change the Cloudant plan from "Shared" to "Lite".

Also updated dependencies and remove references to Redis (this is now handled by the Simple Cache Service).

Don't merge until tested on Bluemix :)