### PR TITLE
(#58) - prefer SSS_CLOUDANT_URL over VCAP_SERVICES

### DIFF
--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -2,20 +2,7 @@
 	CLOUDANT
 *******/
 
-// VCAP_SERVICES
-// This is Bluemix configuration
-if (typeof process.env.VCAP_SERVICES === 'string') {
-	console.log("Using Bluemix config for Cloudant");
-	var services = process.env.VCAP_SERVICES;
-	if (typeof services !== 'undefined') {
-		services = JSON.parse(services);
-	}
-}
-
-// SSS_CLOUDANT_URL
-// Local deploy cloudant configuration
-// URL format: https://<username>:<password>@<hostname>
-else if (typeof process.env.SSS_CLOUDANT_URL === 'string') {
+if (typeof process.env.SSS_CLOUDANT_URL === 'string') {
 	console.log("Using local config for Cloudant");
 	var services = {
 		"cloudantNoSQLDB": [{
@@ -27,6 +14,16 @@ else if (typeof process.env.SSS_CLOUDANT_URL === 'string') {
 			}
 		}]
 	};
+}
+
+// VCAP_SERVICES
+// This is Bluemix configuration
+else if (typeof process.env.VCAP_SERVICES === 'string') {
+	console.log("Using Bluemix config for Cloudant");
+	var services = process.env.VCAP_SERVICES;
+	if (typeof services !== 'undefined') {
+		services = JSON.parse(services);
+	}
 }
 
 module.exports = services;


### PR DESCRIPTION
It's useful to be able to specify a Cloudant URL without binding a service instance (e.g. when using a proxy). Allow SSS_CLOUDANT_URL to always override VCAP_SERVICES when present.